### PR TITLE
Update proxy_callable_impl.h

### DIFF
--- a/main/p0957/mock/proxy_callable_impl.h
+++ b/main/p0957/mock/proxy_callable_impl.h
@@ -13,7 +13,7 @@
  *
  * template <class R, class... Args>
  * facade Callable<R(Args...)> {
- *   R operator()(Args...) &&;
+ *   R operator()(Args...) &;
  * };
  */
 
@@ -38,7 +38,7 @@ struct proxy_meta<Callable<R(Args...)>, E> {
 
  private:
   template <class T>
-  static R f0(E<qualification_type::none, reference_type::rvalue> erased,
+  static R f0(E<qualification_type::none, reference_type::lvalue> erased,
       Args&&... args) {
     if constexpr (is_void_v<R>) {
       erased.template cast<T>()(forward<Args>(args)...);
@@ -47,7 +47,7 @@ struct proxy_meta<Callable<R(Args...)>, E> {
     }
   }
 
-  R (*f0_)(E<qualification_type::none, reference_type::rvalue>, Args&&...);
+  R (*f0_)(E<qualification_type::none, reference_type::lvalue>, Args&&...);
 };
 
 template <class R, class... Args, class A>
@@ -66,8 +66,8 @@ class proxy<Callable<R(Args...)>, A> : public A {
     return *this;
   }
 
-  R operator()(Args... args) && {
-    return A::meta().f0_(move(*this).A::erased(), forward<Args>(args)...);
+  R operator()(Args... args) & {
+    return A::meta().f0_(A::erased(), forward<Args>(args)...);
   }
 };
 


### PR DESCRIPTION
This change is for the sample facade implementation for the PFA (wg21 paper P0957). We have made the decision to change the definition of ‘operator()’ in the facade template ‘Callable’ from rvalue-specified into lvalue-specified. The motivations are:
1. There are cases where a type-erased callable may be invoked multiple times, and
2. Invoking callables with lvalue reference allows state modification by definition, and thus acceptable to consume owning resources by moving them to other contexts.